### PR TITLE
Fix for Hyper Teleport Rock

### DIFF
--- a/src/tools/packet/MTSCSPacket.java
+++ b/src/tools/packet/MTSCSPacket.java
@@ -812,7 +812,7 @@ public class MTSCSPacket {
             for (int i = 0; i < 10; i++) {
                 mplew.writeInt(map[i]);
             }
-        } else if (vip == 3) {
+        } else if (vip == 5) {
             int[] map = chr.getHyperRocks();
             for (int i = 0; i < 13; i++) {
                 mplew.writeInt(map[i]);


### PR DESCRIPTION
Hyper teleport rock is 5 in the packet, not 3.